### PR TITLE
PB-1012 'config.recorderTileViewByDefault' parameter added 

### DIFF
--- a/config.js
+++ b/config.js
@@ -756,6 +756,7 @@ var config = {
      firefox_fake_device
      googleApiApplicationClientID
      iAmRecorder
+     recorderTileViewByDefault
      iAmSipGateway
      microsoftApiApplicationClientID
      peopleSearchQueryTypes

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -134,6 +134,7 @@ export default [
     'hideLobbyButton',
     'hosts',
     'iAmRecorder',
+    'recorderTileViewByDefault',
     'iAmSipGateway',
     'iceTransportPolicy',
     'ignoreStartMuted',

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -140,7 +140,7 @@ export function shouldDisplayTileView(state: Object = {}) {
         return tileViewEnabled;
     }
 
-    const { iAmRecorder } = state['features/base/config'];
+    const { iAmRecorder, recorderTileViewByDefault } = state['features/base/config'];
 
     // None tile view mode is easier to calculate (no need for many negations), so we do
     // that and negate it only once.
@@ -163,6 +163,11 @@ export function shouldDisplayTileView(state: Object = {}) {
         // We want jibri to use stage view by default
         || iAmRecorder
     );
+
+    // Use the tile view for jibri recording if this was requested in the config
+    if (iAmRecorder && recorderTileViewByDefault) {
+        return true;
+    }
 
     return !shouldDisplayNormalMode;
 }


### PR DESCRIPTION
By default Jitsi web is hardcoded to present Jibri (iAmRecorder=true) interface in "normal" mode. 
By setting  `config.recorderTileViewByDefault = true`, jibri will be presented the tile view interface instead